### PR TITLE
Delete universal-ie6.css

### DIFF
--- a/source/assets/css/vendor/universal-ie6.css
+++ b/source/assets/css/vendor/universal-ie6.css
@@ -1,1 +1,0 @@
-/* =include universal-ie6-css/universal-ie6 */


### PR DESCRIPTION
As universal-ie6 is no longer supported, this inclusion breaks the middleman build.
